### PR TITLE
Relationship status change

### DIFF
--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -38,6 +38,11 @@ final case class UserAnswers(
       .getOrElse(None)
       .map(derivable.derive)
 
+  def isDefined(gettable: Gettable[_]): Boolean =
+    Reads.optionNoError(Reads.at[JsValue](gettable.path)).reads(data)
+      .map(_.isDefined)
+      .getOrElse(false)
+
   def set[A](page: Settable[A], value: A)(implicit writes: Writes[A]): Try[UserAnswers] = {
 
     val updatedData = data.setObject(page.path, Json.toJson(value)) match {

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -18,6 +18,7 @@ package pages
 
 import models.{CheckMode, NormalMode, UserAnswers}
 import play.api.mvc.Call
+import queries.Gettable
 
 final case class PageAndWaypoints(page: Page, waypoints: Waypoints) {
 
@@ -49,7 +50,13 @@ trait Page {
     }
 
   protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    waypoints.next.page
+    nextPageNormalMode(waypoints, answers) match {
+      case questionPage: Page with Gettable[_] =>
+        if (answers.isDefined(questionPage)) waypoints.next.page else questionPage
+
+      case otherPage =>
+        otherPage
+    }
 
   protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     IndexPage

--- a/app/pages/RelationshipStatusPage.scala
+++ b/app/pages/RelationshipStatusPage.scala
@@ -19,7 +19,8 @@ package pages
 import controllers.routes
 import models.RelationshipStatus._
 import models.{RelationshipStatus, UserAnswers}
-import pages.income.{ApplicantBenefitsPage, ApplicantIncomeOver50kPage, ApplicantIncomeOver60kPage, ApplicantOrPartnerBenefitsPage, ApplicantOrPartnerIncomeOver50kPage, ApplicantOrPartnerIncomeOver60kPage}
+import pages.income._
+import pages.partner._
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -94,6 +95,16 @@ case object RelationshipStatusPage extends QuestionPage[RelationshipStatus] {
           .flatMap(_.remove(ApplicantOrPartnerIncomeOver50kPage))
           .flatMap(_.remove(ApplicantOrPartnerIncomeOver60kPage))
           .flatMap(_.remove(ApplicantOrPartnerBenefitsPage))
+          .flatMap(_.remove(PartnerNamePage))
+          .flatMap(_.remove(PartnerNinoKnownPage))
+          .flatMap(_.remove(PartnerNinoPage))
+          .flatMap(_.remove(PartnerDateOfBirthPage))
+          .flatMap(_.remove(PartnerNationalityPage))
+          .flatMap(_.remove(PartnerEmploymentStatusPage))
+          .flatMap(_.remove(PartnerEntitledToChildBenefitPage))
+          .flatMap(_.remove(PartnerWaitingForEntitlementDecisionPage))
+          .flatMap(_.remove(PartnerEldestChildNamePage))
+          .flatMap(_.remove(PartnerEldestChildDateOfBirthPage))
 
       case Single | Divorced | Widowed =>
         userAnswers.remove(CohabitationDatePage)
@@ -101,6 +112,16 @@ case object RelationshipStatusPage extends QuestionPage[RelationshipStatus] {
           .flatMap(_.remove(ApplicantOrPartnerIncomeOver50kPage))
           .flatMap(_.remove(ApplicantOrPartnerIncomeOver60kPage))
           .flatMap(_.remove(ApplicantOrPartnerBenefitsPage))
+          .flatMap(_.remove(PartnerNamePage))
+          .flatMap(_.remove(PartnerNinoKnownPage))
+          .flatMap(_.remove(PartnerNinoPage))
+          .flatMap(_.remove(PartnerDateOfBirthPage))
+          .flatMap(_.remove(PartnerNationalityPage))
+          .flatMap(_.remove(PartnerEmploymentStatusPage))
+          .flatMap(_.remove(PartnerEntitledToChildBenefitPage))
+          .flatMap(_.remove(PartnerWaitingForEntitlementDecisionPage))
+          .flatMap(_.remove(PartnerEldestChildNamePage))
+          .flatMap(_.remove(PartnerEldestChildDateOfBirthPage))
 
     }.getOrElse(super.cleanup(value, userAnswers))
 }

--- a/app/pages/applicant/AddApplicantPreviousFamilyNamePage.scala
+++ b/app/pages/applicant/AddApplicantPreviousFamilyNamePage.scala
@@ -18,7 +18,7 @@ package pages.applicant
 
 import controllers.applicant.routes
 import models.{Index, UserAnswers}
-import pages.{AddItemPage, NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{AddItemPage, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import queries.DeriveNumberOfPreviousFamilyNames
@@ -45,17 +45,5 @@ case object AddApplicantPreviousFamilyNamePage extends QuestionPage[Boolean] wit
 
       case false =>
         ApplicantNinoKnownPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers
-          .get(DeriveNumberOfPreviousFamilyNames)
-        .map(n => ApplicantPreviousFamilyNamePage(Index(n)))
-        .orRecover
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 }

--- a/app/pages/applicant/ApplicantHasPreviousFamilyNamePage.scala
+++ b/app/pages/applicant/ApplicantHasPreviousFamilyNamePage.scala
@@ -18,7 +18,7 @@ package pages.applicant
 
 import controllers.applicant.routes
 import models.{Index, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import queries.AllPreviousFamilyNames
@@ -38,17 +38,6 @@ case object ApplicantHasPreviousFamilyNamePage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true => ApplicantPreviousFamilyNamePage(Index(0))
       case false => ApplicantNinoKnownPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(ApplicantPreviousFamilyNamePage(Index(0)))
-          .map(_ => waypoints.next.page)
-          .getOrElse(ApplicantPreviousFamilyNamePage(Index(0)))
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/applicant/ApplicantLivedAtCurrentAddressOneYearPage.scala
+++ b/app/pages/applicant/ApplicantLivedAtCurrentAddressOneYearPage.scala
@@ -39,17 +39,6 @@ case object ApplicantLivedAtCurrentAddressOneYearPage extends QuestionPage[Boole
       case false => ApplicantPreviousAddressPage
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        waypoints.next.page
-
-      case false =>
-        answers.get(ApplicantPreviousAddressPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(ApplicantPreviousAddressPage)
-    }.orRecover
-
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(true)) {
       userAnswers.remove(ApplicantPreviousAddressPage)

--- a/app/pages/applicant/ApplicantNinoKnownPage.scala
+++ b/app/pages/applicant/ApplicantNinoKnownPage.scala
@@ -39,17 +39,6 @@ case object ApplicantNinoKnownPage extends QuestionPage[Boolean] {
       case false => ApplicantDateOfBirthPage
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(ApplicantNinoPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(ApplicantNinoPage)
-
-      case false =>
-        waypoints.next.page
-    }.orRecover
-
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(false)) {
       userAnswers.remove(ApplicantNinoPage)

--- a/app/pages/child/AddChildPreviousNamePage.scala
+++ b/app/pages/child/AddChildPreviousNamePage.scala
@@ -18,7 +18,7 @@ package pages.child
 
 import controllers.child.routes
 import models.{CheckMode, Index, NormalMode, UserAnswers}
-import pages.{AddItemPage, NonEmptyWaypoints, Page, QuestionPage, Waypoint, Waypoints}
+import pages.{AddItemPage, Page, QuestionPage, Waypoint, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import queries.DeriveNumberOfChildPreviousNames
@@ -45,17 +45,6 @@ final case class AddChildPreviousNamePage(index: Index) extends QuestionPage[Boo
 
       case false =>
         ChildBiologicalSexPage(index)
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(DeriveNumberOfChildPreviousNames(index))
-          .map(n => ChildPreviousNamePage(index, Index(n)))
-          .orRecover
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 }
 

--- a/app/pages/child/AnyoneClaimedForChildBeforePage.scala
+++ b/app/pages/child/AnyoneClaimedForChildBeforePage.scala
@@ -18,7 +18,7 @@ package pages.child
 
 import controllers.child.routes
 import models.{Index, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, Waypoints}
+import pages.{Page, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,17 +37,6 @@ final case class AnyoneClaimedForChildBeforePage(index: Index) extends ChildQues
     answers.get(this).map {
       case true  => PreviousClaimantNamePage(index)
       case false => AdoptingChildPage(index)
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(PreviousClaimantNamePage(index))
-          .map(_ => waypoints.next.page)
-          .getOrElse(PreviousClaimantNamePage(index))
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/child/ChildHasPreviousNamePage.scala
+++ b/app/pages/child/ChildHasPreviousNamePage.scala
@@ -18,7 +18,7 @@ package pages.child
 
 import controllers.child.routes
 import models.{Index, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, Waypoints}
+import pages.{Page, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 import queries.AllChildPreviousNames
@@ -40,17 +40,6 @@ final case class ChildHasPreviousNamePage(index: Index) extends ChildQuestionPag
       case false => ChildBiologicalSexPage(index)
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(ChildNameChangedByDeedPollPage(index))
-          .map(_ => waypoints.next.page)
-          .getOrElse(ChildNameChangedByDeedPollPage(index))
-
-      case false =>
-        waypoints.next.page
-
-    }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     value.map {

--- a/app/pages/child/ChildNameChangedByDeedPollPage.scala
+++ b/app/pages/child/ChildNameChangedByDeedPollPage.scala
@@ -18,10 +18,9 @@ package pages.child
 
 import controllers.child.routes
 import models.{Index, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, Waypoints}
+import pages.{Page, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
-import queries.DeriveNumberOfChildPreviousNames
 
 final case class ChildNameChangedByDeedPollPage(index: Index) extends ChildQuestionPage[Boolean] {
 
@@ -34,10 +33,4 @@ final case class ChildNameChangedByDeedPollPage(index: Index) extends ChildQuest
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     ChildPreviousNamePage(index, Index(0))
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(DeriveNumberOfChildPreviousNames(index)).map {
-      case n if n > 0 => waypoints.next.page
-      case _          => ChildPreviousNamePage(index, Index(0))
-    }.getOrElse(ChildPreviousNamePage(index, Index(0)))
 }

--- a/app/pages/child/PreviousClaimantNamePage.scala
+++ b/app/pages/child/PreviousClaimantNamePage.scala
@@ -18,7 +18,7 @@ package pages.child
 
 import controllers.child.routes
 import models.{Index, PreviousClaimantName, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, Waypoints}
+import pages.{Page, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -33,9 +33,4 @@ final case class PreviousClaimantNamePage(index: Index) extends ChildQuestionPag
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     PreviousClaimantAddressPage(index)
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(PreviousClaimantAddressPage(index))
-      .map(_ => waypoints.next.page)
-      .getOrElse(PreviousClaimantAddressPage(index))
 }

--- a/app/pages/income/ApplicantIncomeOver50kPage.scala
+++ b/app/pages/income/ApplicantIncomeOver50kPage.scala
@@ -18,7 +18,7 @@ package pages.income
 
 import controllers.income.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,18 +37,6 @@ case object ApplicantIncomeOver50kPage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true => ApplicantIncomeOver60kPage
       case false => ApplicantBenefitsPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(ApplicantIncomeOver60kPage)
-        .map(_ => waypoints.next.page)
-        .getOrElse(ApplicantIncomeOver60kPage)
-
-      case false =>
-        waypoints.next.page
-
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/income/ApplicantOrPartnerBenefitsPage.scala
+++ b/app/pages/income/ApplicantOrPartnerBenefitsPage.scala
@@ -18,8 +18,9 @@ package pages.income
 
 import controllers.income.routes
 import models.{Benefits, UserAnswers}
+import pages.partner.PartnerNamePage
 import pages.payments.ClaimedChildBenefitBeforePage
-import pages.{Page, QuestionPage, Waypoints}
+import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -34,4 +35,9 @@ case object ApplicantOrPartnerBenefitsPage extends QuestionPage[Set[Benefits]] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     ClaimedChildBenefitBeforePage
+
+  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
+    answers.get(PartnerNamePage)
+      .map(_ => waypoints.next.page)
+      .getOrElse(PartnerNamePage)
 }

--- a/app/pages/income/ApplicantOrPartnerIncomeOver50kPage.scala
+++ b/app/pages/income/ApplicantOrPartnerIncomeOver50kPage.scala
@@ -39,17 +39,17 @@ case object ApplicantOrPartnerIncomeOver50kPage extends QuestionPage[Boolean] {
       case false => ApplicantOrPartnerBenefitsPage
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(ApplicantOrPartnerIncomeOver60kPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(ApplicantOrPartnerIncomeOver60kPage)
-
-      case false =>
-        waypoints.next.page
-
-    }.orRecover
+//  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
+//    answers.get(this).map {
+//      case true =>
+//        answers.get(ApplicantOrPartnerIncomeOver60kPage)
+//          .map(_ => waypoints.next.page)
+//          .getOrElse(ApplicantOrPartnerIncomeOver60kPage)
+//
+//      case false =>
+//        waypoints.next.page
+//
+//    }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(false)) {

--- a/app/pages/income/ApplicantOrPartnerIncomeOver50kPage.scala
+++ b/app/pages/income/ApplicantOrPartnerIncomeOver50kPage.scala
@@ -18,7 +18,7 @@ package pages.income
 
 import controllers.income.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -38,18 +38,6 @@ case object ApplicantOrPartnerIncomeOver50kPage extends QuestionPage[Boolean] {
       case true => ApplicantOrPartnerIncomeOver60kPage
       case false => ApplicantOrPartnerBenefitsPage
     }.orRecover
-
-//  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-//    answers.get(this).map {
-//      case true =>
-//        answers.get(ApplicantOrPartnerIncomeOver60kPage)
-//          .map(_ => waypoints.next.page)
-//          .getOrElse(ApplicantOrPartnerIncomeOver60kPage)
-//
-//      case false =>
-//        waypoints.next.page
-//
-//    }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(false)) {

--- a/app/pages/partner/PartnerEldestChildNamePage.scala
+++ b/app/pages/partner/PartnerEldestChildNamePage.scala
@@ -18,7 +18,7 @@ package pages.partner
 
 import controllers.partner.routes
 import models.{PartnerEldestChildName, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -33,9 +33,4 @@ case object PartnerEldestChildNamePage extends QuestionPage[PartnerEldestChildNa
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     PartnerEldestChildDateOfBirthPage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(PartnerEldestChildDateOfBirthPage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(PartnerEldestChildDateOfBirthPage)
 }

--- a/app/pages/partner/PartnerEntitledToChildBenefitPage.scala
+++ b/app/pages/partner/PartnerEntitledToChildBenefitPage.scala
@@ -18,7 +18,7 @@ package pages.partner
 
 import controllers.partner.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,19 +37,6 @@ case object PartnerEntitledToChildBenefitPage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true => PartnerEldestChildNamePage
       case false => PartnerWaitingForEntitlementDecisionPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(PartnerEldestChildNamePage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(PartnerEldestChildNamePage)
-
-      case false =>
-        answers.get(PartnerWaitingForEntitlementDecisionPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(PartnerWaitingForEntitlementDecisionPage)
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/partner/PartnerNinoKnownPage.scala
+++ b/app/pages/partner/PartnerNinoKnownPage.scala
@@ -39,17 +39,6 @@ case object PartnerNinoKnownPage extends QuestionPage[Boolean] {
       case false => PartnerDateOfBirthPage
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(PartnerNinoPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(PartnerNinoPage)
-
-      case false =>
-        waypoints.next.page
-    }.orRecover
-
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(false)) {
       userAnswers.remove(PartnerNinoPage)

--- a/app/pages/partner/PartnerWaitingForEntitlementDecisionPage.scala
+++ b/app/pages/partner/PartnerWaitingForEntitlementDecisionPage.scala
@@ -40,17 +40,6 @@ case object PartnerWaitingForEntitlementDecisionPage extends QuestionPage[Boolea
       case false => ChildNamePage(Index(0))
     }.orRecover
 
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(PartnerEldestChildNamePage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(PartnerEldestChildNamePage)
-
-      case false =>
-        waypoints.next.page
-    }.orRecover
-
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     if (value.contains(false)) {
       userAnswers.remove(PartnerEldestChildNamePage)

--- a/app/pages/payments/AccountHolderNamePage.scala
+++ b/app/pages/payments/AccountHolderNamePage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -33,9 +33,4 @@ case object AccountHolderNamePage extends QuestionPage[String] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     BankAccountTypePage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(BankAccountTypePage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(BankAccountTypePage)
 }

--- a/app/pages/payments/AccountHolderNamesPage.scala
+++ b/app/pages/payments/AccountHolderNamesPage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.{AccountHolderNames, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -33,9 +33,4 @@ case object AccountHolderNamesPage extends QuestionPage[AccountHolderNames] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     BankAccountTypePage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(BankAccountTypePage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(BankAccountTypePage)
 }

--- a/app/pages/payments/AccountInApplicantsNamePage.scala
+++ b/app/pages/payments/AccountInApplicantsNamePage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,19 +37,6 @@ case object AccountInApplicantsNamePage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true  => BankAccountTypePage
       case false => AccountIsJointPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(BankAccountTypePage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(BankAccountTypePage)
-
-      case false =>
-        answers.get(AccountIsJointPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(AccountIsJointPage)
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/payments/AccountIsJointPage.scala
+++ b/app/pages/payments/AccountIsJointPage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,19 +37,6 @@ case object AccountIsJointPage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true => AccountHolderNamesPage
       case false => AccountHolderNamePage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(AccountHolderNamesPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(AccountHolderNamesPage)
-
-      case false =>
-        answers.get(AccountHolderNamePage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(AccountHolderNamePage)
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/payments/ApplicantHasSuitableAccountPage.scala
+++ b/app/pages/payments/ApplicantHasSuitableAccountPage.scala
@@ -19,7 +19,7 @@ package pages.payments
 import controllers.payments.routes
 import models.UserAnswers
 import pages.applicant.ApplicantHasPreviousFamilyNamePage
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -38,17 +38,6 @@ case object ApplicantHasSuitableAccountPage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true => AccountInApplicantsNamePage
       case false => ApplicantHasPreviousFamilyNamePage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(AccountInApplicantsNamePage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(AccountInApplicantsNamePage)
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/payments/BankAccountTypePage.scala
+++ b/app/pages/payments/BankAccountTypePage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.{BankAccountType, UserAnswers}
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -37,19 +37,6 @@ case object BankAccountTypePage extends QuestionPage[BankAccountType] {
     answers.get(this).map {
       case BankAccountType.Bank => BankAccountDetailsPage
       case BankAccountType.BuildingSociety => BuildingSocietyAccountDetailsPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case BankAccountType.Bank =>
-        answers.get(BankAccountDetailsPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(BankAccountDetailsPage)
-
-      case BankAccountType.BuildingSociety =>
-        answers.get(BuildingSocietyAccountDetailsPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(BuildingSocietyAccountDetailsPage)
     }.orRecover
 
   override def cleanup(value: Option[BankAccountType], userAnswers: UserAnswers): Try[UserAnswers] = {

--- a/app/pages/payments/EldestChildDateOfBirthPage.scala
+++ b/app/pages/payments/EldestChildDateOfBirthPage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -35,9 +35,4 @@ case object EldestChildDateOfBirthPage extends QuestionPage[LocalDate] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     WantToBePaidToExistingAccountPage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(WantToBePaidToExistingAccountPage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(WantToBePaidToExistingAccountPage)
 }

--- a/app/pages/payments/EldestChildNamePage.scala
+++ b/app/pages/payments/EldestChildNamePage.scala
@@ -33,9 +33,4 @@ case object EldestChildNamePage extends QuestionPage[EldestChildName] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     EldestChildDateOfBirthPage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(EldestChildDateOfBirthPage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(EldestChildDateOfBirthPage)
 }

--- a/app/pages/payments/TaxChargeExplanationPage.scala
+++ b/app/pages/payments/TaxChargeExplanationPage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, Waypoints}
+import pages.{Page, Waypoints}
 import play.api.mvc.Call
 
 case object TaxChargeExplanationPage extends Page {
@@ -27,8 +27,5 @@ case object TaxChargeExplanationPage extends Page {
     routes.TaxChargeExplanationController.onPageLoad(waypoints)
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
-    WantToBePaidPage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
     WantToBePaidPage
 }

--- a/app/pages/payments/WantToBePaidPage.scala
+++ b/app/pages/payments/WantToBePaidPage.scala
@@ -22,7 +22,7 @@ import models.RelationshipStatus._
 import models.UserAnswers
 import pages.applicant.ApplicantHasPreviousFamilyNamePage
 import pages.income.ApplicantOrPartnerBenefitsPage
-import pages.{NonEmptyWaypoints, Page, QuestionPage, RelationshipStatusPage, Waypoints}
+import pages.{Page, QuestionPage, RelationshipStatusPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -54,31 +54,6 @@ case object WantToBePaidPage extends QuestionPage[Boolean] {
 
       case false =>
         ApplicantHasPreviousFamilyNamePage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        answers.get(RelationshipStatusPage).map {
-          case Married | Cohabiting =>
-            if (answers.get(ApplicantOrPartnerBenefitsPage).forall(_.intersect(qualifyingBenefits).isEmpty)) {
-              answers.get(ApplicantHasSuitableAccountPage)
-                .map(_ => waypoints.next.page)
-                .getOrElse(ApplicantHasSuitableAccountPage)
-            } else {
-              answers.get(WantToBePaidWeeklyPage)
-                .map(_ => waypoints.next.page)
-                .getOrElse(WantToBePaidWeeklyPage)
-            }
-
-          case Single | Separated | Divorced | Widowed =>
-            answers.get(WantToBePaidWeeklyPage)
-              .map(_ => waypoints.next.page)
-              .getOrElse(WantToBePaidWeeklyPage)
-        }.orRecover
-
-      case false =>
-        waypoints.next.page
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/payments/WantToBePaidToExistingAccountPage.scala
+++ b/app/pages/payments/WantToBePaidToExistingAccountPage.scala
@@ -19,7 +19,7 @@ package pages.payments
 import controllers.payments.routes
 import models.UserAnswers
 import pages.applicant.ApplicantHasPreviousFamilyNamePage
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -38,17 +38,6 @@ case object WantToBePaidToExistingAccountPage extends QuestionPage[Boolean] {
     answers.get(this).map {
       case true  => ApplicantHasPreviousFamilyNamePage
       case false => ApplicantHasSuitableAccountPage
-    }.orRecover
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(this).map {
-      case true =>
-        waypoints.next.page
-
-      case false =>
-        answers.get(ApplicantHasSuitableAccountPage)
-          .map(_ => waypoints.next.page)
-          .getOrElse(ApplicantHasSuitableAccountPage)
     }.orRecover
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =

--- a/app/pages/payments/WantToBePaidWeeklyPage.scala
+++ b/app/pages/payments/WantToBePaidWeeklyPage.scala
@@ -18,7 +18,7 @@ package pages.payments
 
 import controllers.payments.routes
 import models.UserAnswers
-import pages.{NonEmptyWaypoints, Page, QuestionPage, Waypoints}
+import pages.{Page, QuestionPage, Waypoints}
 import play.api.libs.json.JsPath
 import play.api.mvc.Call
 
@@ -33,9 +33,4 @@ case object WantToBePaidWeeklyPage extends QuestionPage[Boolean] {
 
   override protected def nextPageNormalMode(waypoints: Waypoints, answers: UserAnswers): Page =
     ApplicantHasSuitableAccountPage
-
-  override protected def nextPageCheckMode(waypoints: NonEmptyWaypoints, answers: UserAnswers): Page =
-    answers.get(ApplicantHasSuitableAccountPage)
-      .map(_ => waypoints.next.page)
-      .getOrElse(ApplicantHasSuitableAccountPage)
 }

--- a/test/journey/ChangingApplicantSectionJourneySpec.scala
+++ b/test/journey/ChangingApplicantSectionJourneySpec.scala
@@ -40,6 +40,8 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
         submitAnswer(ApplicantPreviousFamilyNamePage(Index(0)), previousName),
         submitAnswer(AddApplicantPreviousFamilyNamePage, true),
         submitAnswer(ApplicantPreviousFamilyNamePage(Index(1)), previousName),
+        submitAnswer(AddApplicantPreviousFamilyNamePage, false),
+        submitAnswer(ApplicantNinoKnownPage, false),
         goTo(CheckYourAnswersPage)
       )
 
@@ -119,6 +121,7 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
 
       val initialise = journeyOf(
         submitAnswer(ApplicantHasPreviousFamilyNamePage, false),
+        submitAnswer(ApplicantNinoKnownPage, false),
         goTo(CheckYourAnswersPage)
       )
 
@@ -205,6 +208,7 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
       val initialise = journeyOf(
         submitAnswer(ApplicantLivedAtCurrentAddressOneYearPage, false),
         submitAnswer(ApplicantPreviousAddressPage, address),
+        submitAnswer(ApplicantPhoneNumberPage, phoneNumber),
         goTo(CheckYourAnswersPage)
       )
 

--- a/test/journey/ChangingApplicantSectionJourneySpec.scala
+++ b/test/journey/ChangingApplicantSectionJourneySpec.scala
@@ -24,11 +24,14 @@ import pages.CheckYourAnswersPage
 import pages.applicant._
 import uk.gov.hmrc.domain.Nino
 
+import java.time.LocalDate
+
 class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelpers with ModelGenerators {
 
   private def previousName = arbitrary[String].sample.value
   private def nino         = arbitrary[Nino].sample.value
   private def address      = arbitrary[Address].sample.value
+  private def phoneNumber  = arbitrary[String].sample.value
 
   "when the user initially said they had previous names" - {
 
@@ -138,6 +141,7 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
       val initialise = journeyOf(
         submitAnswer(ApplicantNinoKnownPage, true),
         submitAnswer(ApplicantNinoPage, nino),
+        submitAnswer(ApplicantDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
 
@@ -158,6 +162,7 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
 
       val initialise = journeyOf(
         submitAnswer(ApplicantNinoKnownPage, false),
+        submitAnswer(ApplicantDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
 
@@ -178,6 +183,7 @@ class ChangingApplicantSectionJourneySpec extends AnyFreeSpec with JourneyHelper
 
       val initialise = journeyOf(
         submitAnswer(ApplicantLivedAtCurrentAddressOneYearPage, true),
+        submitAnswer(ApplicantPhoneNumberPage, phoneNumber),
         goTo(CheckYourAnswersPage)
       )
 

--- a/test/journey/ChangingPartnerSectionJourneySpec.scala
+++ b/test/journey/ChangingPartnerSectionJourneySpec.scala
@@ -40,6 +40,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       val initialise = journeyOf(
         submitAnswer(PartnerNinoKnownPage, true),
         submitAnswer(PartnerNinoPage, nino),
+        submitAnswer(PartnerDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
 
@@ -107,6 +108,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
         submitAnswer(PartnerWaitingForEntitlementDecisionPage, true),
         submitAnswer(PartnerEldestChildNamePage, eldestChildName),
         submitAnswer(PartnerEldestChildDateOfBirthPage, LocalDate.now),
+        submitAnswer(ChildNamePage(Index(0)), childName),
         goTo(CheckYourAnswersPage)
       )
 

--- a/test/journey/ChangingPartnerSectionJourneySpec.scala
+++ b/test/journey/ChangingPartnerSectionJourneySpec.scala
@@ -17,10 +17,11 @@
 package journey
 
 import generators.ModelGenerators
-import models.{ChildName, PartnerEldestChildName}
+import models.{ChildName, Index, PartnerEldestChildName}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.freespec.AnyFreeSpec
 import pages.CheckYourAnswersPage
+import pages.child.ChildNamePage
 import pages.partner._
 import uk.gov.hmrc.domain.Nino
 
@@ -28,8 +29,9 @@ import java.time.LocalDate
 
 class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers with ModelGenerators {
 
-  private def nino      = arbitrary[Nino].sample.value
-  private def childName = arbitrary[PartnerEldestChildName].sample.value
+  private def nino            = arbitrary[Nino].sample.value
+  private def eldestChildName = arbitrary[PartnerEldestChildName].sample.value
+  private def childName       = arbitrary[ChildName].sample.value
 
   "when a user initially said they knew their partner's NINO" - {
 
@@ -58,6 +60,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
 
       val initialise = journeyOf(
         submitAnswer(PartnerNinoKnownPage, false),
+        submitAnswer(PartnerDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
 
@@ -78,7 +81,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
 
       val initialise = journeyOf(
         submitAnswer(PartnerEntitledToChildBenefitPage, true),
-        submitAnswer(PartnerEldestChildNamePage, childName),
+        submitAnswer(PartnerEldestChildNamePage, eldestChildName),
         submitAnswer(PartnerEldestChildDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
@@ -102,7 +105,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       val initialise = journeyOf(
         submitAnswer(PartnerEntitledToChildBenefitPage, false),
         submitAnswer(PartnerWaitingForEntitlementDecisionPage, true),
-        submitAnswer(PartnerEldestChildNamePage, childName),
+        submitAnswer(PartnerEldestChildNamePage, eldestChildName),
         submitAnswer(PartnerEldestChildDateOfBirthPage, LocalDate.now),
         goTo(CheckYourAnswersPage)
       )
@@ -142,6 +145,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
         val initialise = journeyOf(
           submitAnswer(PartnerEntitledToChildBenefitPage, false),
           submitAnswer(PartnerWaitingForEntitlementDecisionPage, false),
+          submitAnswer(ChildNamePage(Index(0)), childName),
           goTo(CheckYourAnswersPage)
         )
 
@@ -150,7 +154,7 @@ class ChangingPartnerSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
             initialise,
             goToChangeAnswer(PartnerWaitingForEntitlementDecisionPage),
             submitAnswer(PartnerWaitingForEntitlementDecisionPage, true),
-            submitAnswer(PartnerEldestChildNamePage, childName),
+            submitAnswer(PartnerEldestChildNamePage, eldestChildName),
             submitAnswer(PartnerEldestChildDateOfBirthPage, LocalDate.now),
             pageMustBe(CheckYourAnswersPage)
           )

--- a/test/journey/ChangingPaymentSectionJourneySpec.scala
+++ b/test/journey/ChangingPaymentSectionJourneySpec.scala
@@ -22,6 +22,7 @@ import models.{AccountHolderNames, BankAccountDetails, BankAccountType, Benefits
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec
+import pages.applicant.ApplicantHasPreviousFamilyNamePage
 import pages.income.ApplicantOrPartnerBenefitsPage
 import pages.{CheckYourAnswersPage, RelationshipStatusPage}
 import pages.payments._
@@ -514,6 +515,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
 
     val initialise = journeyOf(
       submitAnswer(ApplicantHasSuitableAccountPage, false),
+      setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
       goTo(CheckYourAnswersPage)
     )
 
@@ -620,6 +622,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       submitAnswer(BankAccountTypePage, arbitrary[BankAccountType].sample.value),
       setUserAnswerTo(BankAccountDetailsPage, bankDetails),
       setUserAnswerTo(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+      setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
       goTo(CheckYourAnswersPage)
     )
 
@@ -701,6 +704,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       submitAnswer(BankAccountTypePage, arbitrary[BankAccountType].sample.value),
       setUserAnswerTo(BankAccountDetailsPage, bankDetails),
       setUserAnswerTo(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+      setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
       goTo(CheckYourAnswersPage)
     )
 
@@ -795,6 +799,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       val initialise = journeyOf(
         submitAnswer(BankAccountTypePage, BankAccountType.Bank),
         submitAnswer(BankAccountDetailsPage, bankDetails),
+        setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
         goTo(CheckYourAnswersPage)
       )
 
@@ -817,6 +822,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
       val initialise = journeyOf(
         submitAnswer(BankAccountTypePage, BankAccountType.BuildingSociety),
         submitAnswer(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+        setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
         goTo(CheckYourAnswersPage)
       )
 

--- a/test/journey/ChangingPaymentSectionJourneySpec.scala
+++ b/test/journey/ChangingPaymentSectionJourneySpec.scala
@@ -147,6 +147,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
               submitAnswer(BankAccountDetailsPage, bankDetails),
               setUserAnswerTo(AccountHolderNamesPage, accountHolderNames),
               setUserAnswerTo(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+              setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
               goTo(CheckYourAnswersPage)
             )
 
@@ -455,6 +456,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
           setUserAnswerTo(AccountHolderNamePage, "name"),
           setUserAnswerTo(AccountHolderNamesPage, accountHolderNames),
           setUserAnswerTo(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+          setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
           goTo(CheckYourAnswersPage)
         )
 
@@ -491,6 +493,7 @@ class ChangingPaymentSectionJourneySpec extends AnyFreeSpec with JourneyHelpers 
         setUserAnswerTo(AccountHolderNamePage, "name"),
         setUserAnswerTo(AccountHolderNamesPage, accountHolderNames),
         setUserAnswerTo(BuildingSocietyAccountDetailsPage, buildingSocietyDetails),
+        setUserAnswerTo(ApplicantHasPreviousFamilyNamePage, false),
         goTo(CheckYourAnswersPage)
       )
 


### PR DESCRIPTION
This PR also refactors a lot of check mode navigation by changing the default check-mode navigation behaviour from "go back to the waypoint you came from" to "check the next page in the journey: if that's been answered, go back to the waypoint you came from, otherwise go ask that question"