### PR TITLE
CH2-Visual-hidden-fixes

### DIFF
--- a/app/viewmodels/checkAnswers/child/AddChildPreviousNameSummary.scala
+++ b/app/viewmodels/checkAnswers/child/AddChildPreviousNameSummary.scala
@@ -42,20 +42,24 @@ object AddChildPreviousNameSummary {
         )
     }
 
-  def checkAnswersRow(answers: UserAnswers, childIndex: Index, waypoints: Waypoints, sourcePage: CheckAnswersPage)
-                     (implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(AllChildPreviousNames(childIndex)).map {
-      names =>
+def checkAnswersRow(answers: UserAnswers, childIndex: Index, waypoints: Waypoints, sourcePage: CheckAnswersPage)
+                   (implicit messages: Messages): Option[SummaryListRow] =
+  answers.get(AllChildPreviousNames(childIndex)).map {
+    names =>
 
-        val value = HtmlContent(names.map(name => HtmlFormat.escape(name.fullName).toString).mkString("<br/>"))
-
-        SummaryListRowViewModel(
-          key = "addChildPreviousName.checkYourAnswersLabel",
-          value = ValueViewModel(value),
-          actions = Seq(
-            ActionItemViewModel("site.change", AddChildPreviousNamePage(childIndex).changeLink(waypoints, sourcePage).url)
-              .withVisuallyHiddenText(messages("addChildPreviousName.change.hidden"))
-          )
+      val value = HtmlContent(names.map(name => HtmlFormat.escape(name.fullName).toString).mkString("<br/>"))
+      val visuallyHiddenText =
+        names.size match {
+          case 1 => messages("addChildPreviousName.change.hidden.singular")
+          case i => messages("addChildPreviousName.change.hidden.plural")
+        }
+      SummaryListRowViewModel(
+        key = "addChildPreviousName.checkYourAnswersLabel",
+        value = ValueViewModel(value),
+        actions = Seq(
+          ActionItemViewModel("site.change", AddChildPreviousNamePage(childIndex).changeLink(waypoints, sourcePage).url)
+            .withVisuallyHiddenText(messages(visuallyHiddenText))
         )
-    }
+      )
+  }
 }

--- a/app/viewmodels/checkAnswers/child/AddChildSummary.scala
+++ b/app/viewmodels/checkAnswers/child/AddChildSummary.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.addtoalist.ListItem
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
+import viewmodels.checkAnswers.child.AddChildSummary
 
 object AddChildSummary {
 
@@ -48,13 +49,19 @@ object AddChildSummary {
       summaries =>
 
         val value = summaries.map(summary => HtmlFormat.escape(summary.childName.fullName).toString).mkString("<br/>")
+        val children = AddChildSummary.rows(answers, waypoints, AddChildPage)
+        val visuallyHiddenText =
+        children.size match {
+          case 1 => messages("addChild.change.hidden.singular")
+          case i => messages("addChildren.change.hidden.plural")
+        }
 
         SummaryListRowViewModel(
           key = "addChild.checkYourAnswersLabel",
           value = ValueViewModel(HtmlContent(value)),
           actions = Seq(
             ActionItemViewModel("site.change", AddChildPage.changeLink(waypoints, sourcePage).url)
-              .withVisuallyHiddenText(messages("addChild.change.hidden"))
+              .withVisuallyHiddenText(visuallyHiddenText)
           )
         )
     }

--- a/app/viewmodels/checkAnswers/child/ChildHasPreviousNameSummary.scala
+++ b/app/viewmodels/checkAnswers/child/ChildHasPreviousNameSummary.scala
@@ -20,6 +20,8 @@ import models.{Index, UserAnswers}
 import pages.child.ChildHasPreviousNamePage
 import pages.{CheckAnswersPage, Waypoints}
 import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import queries.AllChildPreviousNames
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._

--- a/app/viewmodels/checkAnswers/payments/EldestChildDateOfBirthSummary.scala
+++ b/app/viewmodels/checkAnswers/payments/EldestChildDateOfBirthSummary.scala
@@ -17,7 +17,7 @@
 package viewmodels.checkAnswers.payments
 
 import models.UserAnswers
-import pages.payments.EldestChildDateOfBirthPage
+import pages.payments.{EldestChildDateOfBirthPage, EldestChildNamePage}
 import pages.{CheckAnswersPage, Waypoints}
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
@@ -27,20 +27,22 @@ import viewmodels.implicits._
 import java.time.format.DateTimeFormatter
 
 object EldestChildDateOfBirthSummary {
+  def row (answers: UserAnswers, waypoints: Waypoints, sourcePage: CheckAnswersPage)
+          (implicit messages: Messages): Option[SummaryListRow] =
 
-  def row(answers: UserAnswers, waypoints: Waypoints, sourcePage: CheckAnswersPage)
-         (implicit messages: Messages): Option[SummaryListRow] =
-    answers.get(EldestChildDateOfBirthPage).map {
-      answer =>
+    for{
+      eldestChildName <- answers.get(EldestChildNamePage)
+      dateOfBirth <- answers.get(EldestChildDateOfBirthPage)
+    }yield{
 
-        val dateFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy")
+        val dateFormatter = DateTimeFormatter.ofPattern ("d MMMM yyyy")
 
-        SummaryListRowViewModel(
-          key = "eldestChildDateOfBirth.checkYourAnswersLabel",
-          value = ValueViewModel(answer.format(dateFormatter)),
-          actions = Seq(
-            ActionItemViewModel("site.change", EldestChildDateOfBirthPage.changeLink(waypoints, sourcePage).url)
-              .withVisuallyHiddenText(messages("eldestChildDateOfBirth.change.hidden"))
+        SummaryListRowViewModel (
+          key = messages ("eldestChildDateOfBirth.checkYourAnswersLabel", eldestChildName.firstName),
+          value = ValueViewModel (dateOfBirth.format (dateFormatter) ),
+          actions = Seq (
+            ActionItemViewModel ("site.change", EldestChildDateOfBirthPage.changeLink (waypoints, sourcePage).url)
+              .withVisuallyHiddenText (messages ("eldestChildDateOfBirth.change.hidden") )
           )
         )
     }

--- a/app/views/child/AddChildPreviousNameView.scala.html
+++ b/app/views/child/AddChildPreviousNameView.scala.html
@@ -42,7 +42,7 @@
         case i => messages("addChildPreviousName.heading.plural", i, childName)
     }
 }
-
+addChildPreviousName.heading.plural
 @layout(pageTitle = title(form, titleText)) {
 
     @formHelper(action = routes.AddChildPreviousNameController.onSubmit(waypoints, index), 'autoComplete -> "off") {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -205,6 +205,8 @@ applicantIncome.p2.link.href = https://www.gov.uk/child-benefit-tax-calculator
 applicantIncome.p2.2 = to get an estimate of your adjusted net income
 applicantIncome.error.required = Select your adjusted net income each year
 applicantIncome.error.hidden = your adjusted net income each year
+applicantIncome.checkYourAnswersLabel = What is your adjusted net income each year?
+applicantIncome.change.hidden = your adjusted net yearly income
 
 applicantOrPartnerBenefits.title = Do you or your partner get any of these benefits?
 applicantOrPartnerBenefits.heading = Do you or your partner get any of these benefits?
@@ -700,17 +702,21 @@ addChild.checkYourAnswersLabel = Children
 addChild.addAnother = Do you need to add another child?
 addChild.error.required = Select yes if you need to add another child
 addChild.change.hidden = the details for {0}
+addChild.change.hidden.singular = the details of the child
+addChildren.change.hidden.plural = the details of the children
 addChild.remove.hidden = {0}
 
 addChildPreviousName.title.plural = You have added {0} previous names
 addChildPreviousName.title.singular = You have added 1 previous name
-addChildPreviousName.heading.plural = You have added {0} previous names for {0}
+addChildPreviousName.heading.plural = You have added {0} previous names for {1}
 addChildPreviousName.heading.singular = You have added 1 previous name for {0}
 addChildPreviousName.checkYourAnswersLabel = Previous names
 addChildPreviousName.addAnother = Do you need to add another previous name for {0}?
 addChildPreviousName.error.required = Select yes if you need to add another previous name
 addChildPreviousName.change.hidden = the previous name {0}
 addChildPreviousName.remove.hidden = {0}
+addChildPreviousName.change.hidden.singular = this child previous name
+addChildPreviousName.change.hidden.plural = this child previous names
 
 anyoneClaimedForChildBefore.title = Have you or anyone else ever claimed Child Benefit for this child?
 anyoneClaimedForChildBefore.heading = Have you or anyone else ever claimed Child Benefit for {0}?


### PR DESCRIPTION
- Added messages for the check your answers page related to the Income details 

- Fixed name parsing issue on the check your answers page, which showed {0} instead of the eldest child firstname

- Fixed title in child previous name summary page which for more than one name showed : "You have added 2 previous names for 2" (in the case of 2 previous names) instead of "You have added 2 previous names for <name of the child>.

- Fixed hidden message parsing error on check your answers page when the number of children was greater than 1. Read "the details of {0}. Now reads "the details of the child" for one child and "the details of the children" for more than one child.

- Added hidden messages on check your answers page for previous names. Now reads "this child previous name" for one previous name and "this child previous names" for more than one previous names.
