### PR TITLE
SB-1922: New text content for the /sign-in-to-government-gateway page

### DIFF
--- a/app/views/SignInView.scala.html
+++ b/app/views/SignInView.scala.html
@@ -14,13 +14,18 @@
  * limitations under the License.
  *@
 
+@import components._
+
 @this(
         layout: templates.Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
         govukButton: GovukButton,
-        govukWarningText: GovukWarningText
+        govukWarningText: GovukWarningText,
+        heading: Heading,
+        list: BulletList,
+        paragraph: ParagraphBody
 )
 
 @(form: Form[_], waypoints: Waypoints)(implicit request: Request[_], messages: Messages)
@@ -33,9 +38,17 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">@messages("signIn.heading")</h1>
+        @heading(messages("signIn.heading"), classes = "govuk-heading-xl govuk-!-margin-bottom-3")
 
-        <p class="govuk-body">@messages("signIn.p1")</p>
+        @paragraph(messages("signIn.p1"))
+
+        @paragraph(messages("signIn.p2"))
+
+        @list(elements = Seq(
+            Html(messages("signIn.bullet1")),
+            Html(messages("signIn.bullet2")),
+            Html(messages("signIn.bullet3"))
+        ))
 
         @govukRadios(
             RadiosViewModel.yesNo(

--- a/app/views/components/BulletList.scala.html
+++ b/app/views/components/BulletList.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(elements: Seq[Html], classes: String = "govuk-list govuk-list--bullet", id: Option[String] = None)
+
+<ul class="@classes" @id.map{id => id="@id"}>
+    @elements.map { element =>
+        <li class="dashed-list-item">
+            @element
+        </li>
+    }
+</ul>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -471,7 +471,11 @@ journeyRecovery.startAgain.p2.2 = os ydych am siarad â rhywun ynglŷn â hawlio
 
 signIn.title = A ydych am fewngofnodi drwy ddefnyddio Porth y Llywodraeth?
 signIn.heading = A ydych am fewngofnodi drwy ddefnyddio Porth y Llywodraeth?
-signIn.p1 = Os ydych yn mewngofnodi ac yn cadarnhau pwy ydych, byddwch yn gallu llenwi’r hawliad hwn yn gyflymach.
+signIn.p1 = Os nad oes gennych gyfrif personol ar gyfer Porth y Llywodraeth, gallwch greu un.
+signIn.p2 = Pan fyddwch yn mewngofnodi, gallwch wneud y canlynol:
+signIn.bullet1 = cael eich Budd-dal Plant yn gynharach
+signIn.bullet2 = cadw’ch cynnydd
+signIn.bullet3 = llenwi’r ffurflen hon yn gyflymach
 signIn.error.required = Dewiswch ’Iawn’ os ydych am fewngofnodi drwy ddefnyddio Porth y Llywodraeth
 
 signedOut.title = Gwnaethom gadw’ch cynnydd

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -471,7 +471,11 @@ journeyRecovery.startAgain.p2.2 = if you need to speak to someone about claiming
 
 signIn.title = Do you want to sign in using Government Gateway?
 signIn.heading = Do you want to sign in using Government Gateway?
-signIn.p1 = If you sign in and verify your identity, you will be able to complete this claim faster.
+signIn.p1 = You can create a personal Government Gateway account if you do not have one.
+signIn.p2 = When you sign in, you can:
+signIn.bullet1 = get your Child Benefit earlier
+signIn.bullet2 = save your progress
+signIn.bullet3 = complete this form faster
 signIn.error.required = Select yes if you want to sign in using Government Gateway
 
 signedOut.title = We saved your progress


### PR DESCRIPTION
[[SB-1922]](https://jira.tools.tax.service.gov.uk/browse/SB-1922) New text content for the /sign-in-to-government-gateway page as a result of the Optimizily A/B testing

New English:
<img width="1001" alt="SB-1922 - English" src="https://github.com/hmrc/claim-child-benefit-frontend/assets/11579453/dadebe44-f018-4eeb-a352-c7fbf1f41061">

New Welsh:
<img width="1001" alt="SB-1922 - Cymraeg" src="https://github.com/hmrc/claim-child-benefit-frontend/assets/11579453/0b4c7982-7060-4af1-be47-6f7d828aef0d">
